### PR TITLE
Improve UI visibility with lighter colors

### DIFF
--- a/client/public/datacenter-bg.svg
+++ b/client/public/datacenter-bg.svg
@@ -2,16 +2,16 @@
   <!-- Background -->
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1a1a2e;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#16213e;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0f1419;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#2c3350;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#273d66;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#212b39;stop-opacity:1" />
     </linearGradient>
     <linearGradient id="floorGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#2a2a3a;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1a1a2a;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#4a4a5a;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#30303c;stop-opacity:1" />
     </linearGradient>
     <pattern id="gridPattern" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse">
-      <rect width="60" height="60" fill="none" stroke="#333" stroke-width="1" opacity="0.3"/>
+      <rect width="60" height="60" fill="none" stroke="#555" stroke-width="1" opacity="0.3"/>
     </pattern>
   </defs>
   
@@ -23,53 +23,53 @@
   <rect x="0" y="700" width="1920" height="380" fill="url(#gridPattern)"/>
   
   <!-- Server Racks - Left Side -->
-  <g id="leftRacks">
-    <rect x="50" y="300" width="80" height="400" fill="#1a1a1a" stroke="#333" stroke-width="2"/>
+    <g id="leftRacks">
+      <rect x="50" y="300" width="80" height="400" fill="#3a3a3a" stroke="#555" stroke-width="2"/>
     <rect x="60" y="320" width="60" height="15" fill="#00ff00" opacity="0.6"/>
     <rect x="60" y="350" width="60" height="15" fill="#ff8800" opacity="0.6"/>
     <rect x="60" y="380" width="60" height="15" fill="#0088ff" opacity="0.6"/>
     
-    <rect x="150" y="250" width="80" height="450" fill="#1a1a1a" stroke="#333" stroke-width="2"/>
+    <rect x="150" y="250" width="80" height="450" fill="#3a3a3a" stroke="#555" stroke-width="2"/>
     <rect x="160" y="270" width="60" height="15" fill="#00ff00" opacity="0.6"/>
     <rect x="160" y="300" width="60" height="15" fill="#00ff00" opacity="0.6"/>
     <rect x="160" y="330" width="60" height="15" fill="#ff8800" opacity="0.6"/>
   </g>
   
   <!-- Server Racks - Right Side -->
-  <g id="rightRacks">
-    <rect x="1690" y="280" width="80" height="420" fill="#1a1a1a" stroke="#333" stroke-width="2"/>
+    <g id="rightRacks">
+      <rect x="1690" y="280" width="80" height="420" fill="#3a3a3a" stroke="#555" stroke-width="2"/>
     <rect x="1700" y="300" width="60" height="15" fill="#00ff00" opacity="0.6"/>
     <rect x="1700" y="330" width="60" height="15" fill="#00ff00" opacity="0.6"/>
     <rect x="1700" y="360" width="60" height="15" fill="#ff8800" opacity="0.6"/>
     
-    <rect x="1590" y="320" width="80" height="380" fill="#1a1a1a" stroke="#333" stroke-width="2"/>
+      <rect x="1590" y="320" width="80" height="380" fill="#3a3a3a" stroke="#555" stroke-width="2"/>
     <rect x="1600" y="340" width="60" height="15" fill="#0088ff" opacity="0.6"/>
     <rect x="1600" y="370" width="60" height="15" fill="#ff8800" opacity="0.6"/>
   </g>
   
   <!-- Overhead Cable Trays -->
-  <g id="cableTrays">
-    <rect x="300" y="150" width="1320" height="20" fill="#444" stroke="#555" stroke-width="1"/>
-    <rect x="300" y="180" width="1320" height="20" fill="#444" stroke="#555" stroke-width="1"/>
+    <g id="cableTrays">
+      <rect x="300" y="150" width="1320" height="20" fill="#666" stroke="#777" stroke-width="1"/>
+      <rect x="300" y="180" width="1320" height="20" fill="#666" stroke="#777" stroke-width="1"/>
     
     <!-- Support beams -->
-    <rect x="500" y="150" width="8" height="50" fill="#666"/>
-    <rect x="800" y="150" width="8" height="50" fill="#666"/>
-    <rect x="1100" y="150" width="8" height="50" fill="#666"/>
-    <rect x="1400" y="150" width="8" height="50" fill="#666"/>
+      <rect x="500" y="150" width="8" height="50" fill="#888"/>
+      <rect x="800" y="150" width="8" height="50" fill="#888"/>
+      <rect x="1100" y="150" width="8" height="50" fill="#888"/>
+      <rect x="1400" y="150" width="8" height="50" fill="#888"/>
   </g>
   
   <!-- Wall Panels -->
   <g id="wallPanels">
     <!-- Left wall panels -->
-    <rect x="20" y="100" width="30" height="200" fill="#2a2a2a" stroke="#444" stroke-width="1"/>
+      <rect x="20" y="100" width="30" height="200" fill="#444" stroke="#666" stroke-width="1"/>
     <rect x="25" y="120" width="20" height="20" fill="#00aa00" opacity="0.8"/>
-    <rect x="25" y="150" width="20" height="30" fill="#333"/>
+      <rect x="25" y="150" width="20" height="30" fill="#555"/>
     
     <!-- Right wall panels -->
-    <rect x="1870" y="120" width="30" height="180" fill="#2a2a2a" stroke="#444" stroke-width="1"/>
+      <rect x="1870" y="120" width="30" height="180" fill="#444" stroke="#666" stroke-width="1"/>
     <rect x="1875" y="140" width="20" height="20" fill="#ff4400" opacity="0.8"/>
-    <rect x="1875" y="170" width="20" height="30" fill="#333"/>
+      <rect x="1875" y="170" width="20" height="30" fill="#555"/>
   </g>
   
   <!-- Ceiling Lights -->
@@ -86,18 +86,18 @@
   </g>
   
   <!-- Ventilation -->
-  <g id="ventilation">
-    <rect x="400" y="40" width="120" height="20" fill="#333" stroke="#555" stroke-width="1"/>
-    <rect x="600" y="40" width="120" height="20" fill="#333" stroke="#555" stroke-width="1"/>
-    <rect x="1200" y="40" width="120" height="20" fill="#333" stroke="#555" stroke-width="1"/>
-    <rect x="1400" y="40" width="120" height="20" fill="#333" stroke="#555" stroke-width="1"/>
+    <g id="ventilation">
+      <rect x="400" y="40" width="120" height="20" fill="#555" stroke="#777" stroke-width="1"/>
+      <rect x="600" y="40" width="120" height="20" fill="#555" stroke="#777" stroke-width="1"/>
+      <rect x="1200" y="40" width="120" height="20" fill="#555" stroke="#777" stroke-width="1"/>
+      <rect x="1400" y="40" width="120" height="20" fill="#555" stroke="#777" stroke-width="1"/>
   </g>
   
   <!-- Floor cables -->
-  <g id="floorCables">
-    <path d="M 200 750 Q 500 730 800 750 Q 1100 770 1400 750 Q 1600 730 1700 750" 
-          stroke="#444" stroke-width="3" fill="none" opacity="0.6"/>
-    <path d="M 180 780 Q 400 760 600 780 Q 900 800 1200 780 Q 1500 760 1720 780" 
-          stroke="#444" stroke-width="3" fill="none" opacity="0.6"/>
+    <g id="floorCables">
+      <path d="M 200 750 Q 500 730 800 750 Q 1100 770 1400 750 Q 1600 730 1700 750" 
+          stroke="#666" stroke-width="3" fill="none" opacity="0.6"/>
+      <path d="M 180 780 Q 400 760 600 780 Q 900 800 1200 780 Q 1500 760 1720 780" 
+          stroke="#666" stroke-width="3" fill="none" opacity="0.6"/>
   </g>
 </svg>

--- a/client/src/components/EscapeRoom.tsx
+++ b/client/src/components/EscapeRoom.tsx
@@ -57,7 +57,7 @@ export default function EscapeRoom() {
           maxHeight: '100%',
           margin: '0 auto',
           display: 'block',
-          background: 'rgba(17, 17, 17, 0.7)'
+          background: 'rgba(34, 34, 34, 0.7)'
         }}
       >
         <Suspense fallback={null}>

--- a/client/src/components/Scene3D.tsx
+++ b/client/src/components/Scene3D.tsx
@@ -33,7 +33,7 @@ export default function Scene3D() {
           position={[(i - 3.5) * 2, 0.01, (j - 3.5) * 2]}
         >
           <planeGeometry args={[1.8, 1.8]} />
-          <meshStandardMaterial color="#333" transparent opacity={0.5} />
+          <meshStandardMaterial color="#555" transparent opacity={0.5} />
         </mesh>
       ))
     ),
@@ -147,7 +147,7 @@ export default function Scene3D() {
   return (
     <>
       {/* Data center lighting */}
-      <ambientLight intensity={0.3} color="#1a1a2e" />
+      <ambientLight intensity={0.5} color="#2c3350" />
       <directionalLight position={[5, 10, 5]} intensity={0.8} color="#ffffff" castShadow />
       <pointLight position={[-3, 2, -2]} intensity={0.5} color="#00ff00" />
       <pointLight position={[3, 2, -2]} intensity={0.5} color="#00aa00" />
@@ -156,7 +156,7 @@ export default function Scene3D() {
       {/* Data center floor - raised floor tiles */}
       <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
         <planeGeometry args={[15, 15]} />
-        <meshStandardMaterial color="#2a2a2a" />
+        <meshStandardMaterial color="#444" />
       </mesh>
       
       {/* Floor grid pattern */}
@@ -166,7 +166,7 @@ export default function Scene3D() {
       <group ref={keypadRef} position={[-3, 1.2, -2]}>
         <mesh position={[0, 0, 0]}>
           <boxGeometry args={[0.8, 1.5, 0.3]} />
-          <meshStandardMaterial color="#1a1a1a" />
+          <meshStandardMaterial color="#3a3a3a" />
         </mesh>
         <mesh position={[0, 0.3, 0.16]}>
           <boxGeometry args={[0.6, 0.4, 0.02]} />
@@ -174,7 +174,7 @@ export default function Scene3D() {
         </mesh>
         <mesh position={[0, -0.2, 0.16]}>
           <boxGeometry args={[0.7, 0.8, 0.02]} />
-          <meshStandardMaterial color="#333333" />
+          <meshStandardMaterial color="#555" />
         </mesh>
       </group>
       
@@ -220,7 +220,7 @@ export default function Scene3D() {
       {/* Network Panel (was painting) */}
       <mesh ref={paintingRef} position={[3, 1.5, -2]} rotation={[0, -Math.PI / 6, 0]}>
         <boxGeometry args={[1.2, 0.8, 0.1]} />
-        <meshStandardMaterial color="#2a2a2a" />
+        <meshStandardMaterial color="#555" />
       </mesh>
       <mesh position={[3, 1.5, -1.95]} rotation={[0, -Math.PI / 6, 0]}>
         <planeGeometry args={[1, 0.6]} />
@@ -252,11 +252,11 @@ export default function Scene3D() {
       {/* Wall-mounted electrical panels */}
       <mesh position={[-4, 1.5, 0]}>
         <boxGeometry args={[0.2, 1, 0.8]} />
-        <meshStandardMaterial color="#333333" />
+        <meshStandardMaterial color="#555" />
       </mesh>
       <mesh position={[4, 1.5, 0]}>
         <boxGeometry args={[0.2, 1, 0.8]} />
-        <meshStandardMaterial color="#333333" />
+        <meshStandardMaterial color="#555" />
       </mesh>
     </>
   );

--- a/client/src/components/puzzles/GearPuzzle.tsx
+++ b/client/src/components/puzzles/GearPuzzle.tsx
@@ -45,7 +45,7 @@ function GearPuzzle() {
   }
 
   return (
-    <div className="border border-blue-500 p-2 bg-black bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
+    <div className="border border-blue-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
       <div className="text-blue-400 text-sm mb-2 font-mono">Install Tools:</div>
       <div className="flex gap-2 mb-2">
         {!gear1Placed && (

--- a/client/src/components/puzzles/KeypadPuzzle.tsx
+++ b/client/src/components/puzzles/KeypadPuzzle.tsx
@@ -25,14 +25,14 @@ function KeypadPuzzle() {
   }
 
   return (
-    <div className="border border-red-500 p-2 bg-black bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
+    <div className="border border-red-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
       <div className="text-red-400 text-sm mb-2 font-mono">PDU Access Code:</div>
       <div className="flex gap-1">
         <input
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          className="w-16 px-1 text-green-400 text-sm bg-black border border-gray-600 font-mono hover:border-green-500 transition-colors duration-200"
+          className="w-16 px-1 text-green-400 text-sm bg-gray-900 border border-gray-600 font-mono hover:border-green-500 transition-colors duration-200"
           maxLength={3}
           placeholder="000"
         />

--- a/client/src/components/puzzles/ROT13Puzzle.tsx
+++ b/client/src/components/puzzles/ROT13Puzzle.tsx
@@ -24,13 +24,13 @@ function ROT13Puzzle() {
   }
 
   return (
-    <div className="border border-purple-500 p-2 bg-black bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
+    <div className="border border-purple-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
       <div className="text-purple-400 text-sm mb-1 font-mono">Error Code: RPDU</div>
       <input
         type="text"
         value={input}
         onChange={handleChange}
-        className="w-20 px-1 text-purple-400 text-sm bg-black border border-gray-600 font-mono hover:border-purple-500 transition-colors duration-200 cursor-text"
+        className="w-20 px-1 text-purple-400 text-sm bg-gray-900 border border-gray-600 font-mono hover:border-purple-500 transition-colors duration-200 cursor-text"
         placeholder="????"
       />
       <div className="text-xs text-gray-400 mt-1">Decode to resolve</div>

--- a/client/src/components/puzzles/SliderPuzzle.tsx
+++ b/client/src/components/puzzles/SliderPuzzle.tsx
@@ -25,7 +25,7 @@ function SliderPuzzle() {
   }
 
   return (
-    <div className="border border-orange-500 p-2 bg-black bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
+    <div className="border border-orange-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
       <div className="text-orange-400 text-sm mb-1 font-mono">Power Level: {value}%</div>
       <input
         type="range"

--- a/client/src/components/ui/EndScreen.tsx
+++ b/client/src/components/ui/EndScreen.tsx
@@ -12,11 +12,11 @@ export default function EndScreen() {
   return (
     <div className={`absolute inset-0 flex items-center justify-center ${
       isSuccess 
-        ? 'bg-gradient-to-b from-green-900 via-blue-900 to-black' 
-        : 'bg-gradient-to-b from-red-900 via-gray-900 to-black'
+        ? 'bg-gradient-to-b from-green-800 via-blue-800 to-gray-900'
+        : 'bg-gradient-to-b from-red-800 via-gray-800 to-gray-900'
     }`}>
       <div className="max-w-2xl mx-auto p-8 text-center">
-        <div className="bg-black bg-opacity-70 rounded-lg p-8 border-2 border-opacity-50" 
+        <div className="bg-gray-800 bg-opacity-80 rounded-lg p-8 border-2 border-opacity-50"
              style={{ borderColor: isSuccess ? '#10b981' : '#ef4444' }}>
           
           <h1 className={`text-5xl font-bold mb-6 ${

--- a/client/src/components/ui/GameOverlay.tsx
+++ b/client/src/components/ui/GameOverlay.tsx
@@ -41,7 +41,7 @@ function GameOverlay() {
         
         {/* PDU Status Display */}
         <div className="absolute top-4 left-4 pointer-events-auto">
-          <div className="bg-black bg-opacity-90 border border-gray-600 p-3 rounded font-mono text-sm">
+          <div className="bg-gray-800 bg-opacity-90 border border-gray-500 p-3 rounded font-mono text-sm">
             <div className="text-yellow-400 mb-2">PDU Status:</div>
             <div className="space-y-1">
               <div className={`${solved[0] ? 'text-green-400' : 'text-red-400'}`}>

--- a/client/src/components/ui/HintSystem.tsx
+++ b/client/src/components/ui/HintSystem.tsx
@@ -37,7 +37,7 @@ export default function HintSystem() {
 
   return (
     <div className="absolute top-4 right-20 max-w-xs pointer-events-auto">
-      <div className="bg-black bg-opacity-90 border border-yellow-500 p-3 rounded font-mono text-sm">
+      <div className="bg-gray-800 bg-opacity-90 border border-yellow-500 p-3 rounded font-mono text-sm">
         <div className="text-yellow-400 mb-2 text-center">Hint System</div>
         <div className="text-xs text-gray-400 mb-2 text-center">
           Cost: 1 minute per hint

--- a/client/src/components/ui/SequenceIndicator.tsx
+++ b/client/src/components/ui/SequenceIndicator.tsx
@@ -18,7 +18,7 @@ function SequenceIndicator() {
 
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 pointer-events-auto">
-      <div className="bg-black bg-opacity-90 border border-gray-600 p-2 rounded font-mono text-xs">
+      <div className="bg-gray-800 bg-opacity-90 border border-gray-500 p-2 rounded font-mono text-xs">
         <div className="text-gray-400 mb-1 text-center">Activation Sequence</div>
         <div className="flex gap-1">
           {targetSequence.map((targetColor, index) => {

--- a/client/src/components/ui/Timer.tsx
+++ b/client/src/components/ui/Timer.tsx
@@ -21,8 +21,8 @@ export default function Timer() {
   return (
     <div className={`fixed top-4 right-4 z-50 px-4 py-2 rounded-lg border-2 font-mono text-lg font-bold ${
       isLowTime 
-        ? 'bg-red-900 border-red-500 text-red-200 animate-pulse' 
-        : 'bg-gray-900 border-blue-500 text-blue-200'
+        ? 'bg-red-900 border-red-500 text-red-200 animate-pulse'
+        : 'bg-gray-800 border-blue-500 text-blue-200'
     }`}>
       <div className="flex items-center gap-2">
         <span className="text-sm">⏱</span>

--- a/client/src/components/ui/TitleScreen.tsx
+++ b/client/src/components/ui/TitleScreen.tsx
@@ -6,7 +6,7 @@ export default function TitleScreen() {
   const { start } = useGame();
 
   return (
-    <div className="absolute inset-0 bg-gradient-to-b from-gray-900 via-blue-900 to-black flex items-center justify-center">
+    <div className="absolute inset-0 bg-gradient-to-b from-gray-800 via-blue-800 to-gray-900 flex items-center justify-center">
       <div className="max-w-4xl mx-auto p-8 text-center">
         <div className="mb-8">
           <h1 className="text-6xl font-bold text-white mb-4 tracking-wide">
@@ -17,7 +17,7 @@ export default function TitleScreen() {
           </h2>
         </div>
         
-        <div className="bg-black bg-opacity-50 rounded-lg p-8 mb-8 border border-blue-500">
+        <div className="bg-gray-800 bg-opacity-70 rounded-lg p-8 mb-8 border border-blue-500">
           <h3 className="text-xl text-yellow-400 font-semibold mb-6">Instructions:</h3>
           
           <div className="text-left space-y-4 text-gray-200">

--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -17,7 +17,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-neutral-900/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -22,7 +22,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-neutral-900/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/client/src/components/ui/drawer.tsx
+++ b/client/src/components/ui/drawer.tsx
@@ -29,7 +29,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("fixed inset-0 z-50 bg-neutral-900/80", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/interface.tsx
+++ b/client/src/components/ui/interface.tsx
@@ -53,7 +53,7 @@ export function Interface() {
       
       {/* Game completion overlay */}
       {phase === "ended" && (
-        <div className="fixed inset-0 flex items-center justify-center z-20 bg-black/30">
+        <div className="fixed inset-0 flex items-center justify-center z-20 bg-neutral-900/40">
           <Card className="w-full max-w-md mx-4 shadow-lg">
             <CardHeader>
               <CardTitle className="flex items-center justify-center gap-2">

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -22,7 +22,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-neutral-900/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- brighten datacenter background SVG colors
- lighten ambient lighting and floor colors in the 3D scene
- use lighter gray backgrounds for puzzle and status panels
- soften gradient backgrounds on title and end screens
- adjust overlay shades on dialogs and sheets

## Testing
- `npm run check` *(fails: Cannot find module '../game/Confetti' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68489b2b9cb8832b9ec3b001751c31f9