### PR TITLE
Fix interface typing and server options

### DIFF
--- a/client/src/components/game/Confetti.tsx
+++ b/client/src/components/game/Confetti.tsx
@@ -1,0 +1,8 @@
+// NOTE: client/src/components/game/Confetti.tsx - placeholder to satisfy TypeScript
+import React from "react";
+
+export function Confetti() {
+  return null;
+}
+
+export default Confetti;

--- a/client/src/components/ui/interface.tsx
+++ b/client/src/components/ui/interface.tsx
@@ -14,9 +14,9 @@ export function Interface() {
 
   // Handle clicks on the interface in the ready phase to start the game
   useEffect(() => {
-    if (phase === "ready") {
+    if (phase === "title") {
       const handleClick = () => {
-        document.activeElement?.blur(); // Remove focus from any button
+        (document.activeElement as HTMLElement | null)?.blur(); // Remove focus from any button
         const event = new KeyboardEvent("keydown", { code: "Space" });
         window.dispatchEvent(event);
       };
@@ -52,7 +52,7 @@ export function Interface() {
       </div>
       
       {/* Game completion overlay */}
-      {phase === "ended" && (
+      {phase === "success" && (
         <div className="fixed inset-0 flex items-center justify-center z-20 bg-neutral-900/40">
           <Card className="w-full max-w-md mx-4 shadow-lg">
             <CardHeader>

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,7 +3,7 @@ import express, { type Express } from "express";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { type Server } from "http";
@@ -24,7 +24,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- silence TypeScript errors by adding placeholder `Confetti` component
- update `Interface` hooks and overlay checks to match store types
- type `serverOptions` in `server/vite.ts`
- run `npm run check`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6849f4bd5994832b8a8f4b0c378720d9