### PR TITLE
Add Confetti overlay component

### DIFF
--- a/client/src/components/game/Confetti.tsx
+++ b/client/src/components/game/Confetti.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import ReactConfetti from "react-confetti";
+import { useGame } from "@/lib/stores/useGame";
+
+export function Confetti() {
+  const phase = useGame((state) => state.phase);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const update = () => {
+      setDimensions({ width: window.innerWidth, height: window.innerHeight });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  if (phase !== "success") return null;
+  return (
+    <ReactConfetti
+      width={dimensions.width}
+      height={dimensions.height}
+      numberOfPieces={300}
+      recycle={false}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a lightweight Confetti component for the client game

## Testing
- `npm run check` *(fails: cannot compile due to existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4ba0544832bbd746a39c687c774