### PR TITLE
Add power maintenance puzzle theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # PDU Game
 
-This is a simple escape room style game built with React and Three.js. The objective is to solve a series of puzzles to repair a rack PDU and escape the data center.
+This is a simple escape room style game built with React and Three.js. The objective is to solve six power-related puzzles to repair a rack PDU and escape the data center.
+
+## Puzzles
+
+1. **Reset Breaker** – enter the correct code to clear the tripped breaker.
+2. **Repatch Whip** – click the colored connectors in the correct order.
+3. **Balance Phases** – interact with the phase meter to stabilize the load.
+4. **Replace Fuse** – adjust the fuse rating slider to the target value.
+5. **Bypass EPO** – drag the jumpers into place to bypass the EPO circuit.
+6. **Reboot Controller** – decode the displayed string to restart the PDU.
 
 ## Development
 

--- a/client/src/components/Scene3D.tsx
+++ b/client/src/components/Scene3D.tsx
@@ -13,7 +13,7 @@ export default function Scene3D() {
   
   // Object refs
   const keypadRef = useRef<any>(null);
-  const paintingRef = useRef<Mesh>(null);
+  const phaseMeterRef = useRef<Mesh>(null);
   const redBoxRef = useRef<Mesh>(null);
   const redBoxTopRef = useRef<Mesh>(null);
   const greenBoxRef = useRef<Mesh>(null);
@@ -67,7 +67,7 @@ export default function Scene3D() {
     
     const objects = [
       keypadRef.current,
-      paintingRef.current,
+      phaseMeterRef.current,
       redBoxRef.current,
       redBoxTopRef.current,
       greenBoxRef.current,
@@ -106,7 +106,7 @@ export default function Scene3D() {
     
     const objects = [
       keypadRef.current,
-      paintingRef.current,
+      phaseMeterRef.current,
       redBoxRef.current,
       redBoxTopRef.current,
       greenBoxRef.current,
@@ -123,11 +123,11 @@ export default function Scene3D() {
       const clickedObject = intersects[0].object;
       
       if (clickedObject === keypadRef.current || clickedObject.parent === keypadRef.current) {
-        const code = prompt('Enter PDU access code:');
+        const code = prompt('Enter breaker reset code:');
         if (code === '314') {
           solvePuzzle(0);
         }
-      } else if (clickedObject === paintingRef.current) {
+      } else if (clickedObject === phaseMeterRef.current) {
         solvePuzzle(2);
       } else if (
         clickedObject === redBoxRef.current ||
@@ -245,8 +245,8 @@ export default function Scene3D() {
         </mesh>
       </group>
       
-      {/* Network Panel (was painting) */}
-      <mesh ref={paintingRef} position={[3, 1.5, -2]} rotation={[0, -Math.PI / 6, 0]}>
+      {/* Phase Meter */}
+      <mesh ref={phaseMeterRef} position={[3, 1.5, -2]} rotation={[0, -Math.PI / 6, 0]}>
         <boxGeometry args={[1.2, 0.8, 0.1]} />
         <meshStandardMaterial color="#555" />
       </mesh>

--- a/client/src/components/puzzles/GearPuzzle.tsx
+++ b/client/src/components/puzzles/GearPuzzle.tsx
@@ -39,14 +39,14 @@ function GearPuzzle() {
   if (solved[4]) {
     return (
       <div className="border border-green-500 p-2 bg-green-900 bg-opacity-90 rounded">
-        <span className="text-green-400">✓ Tools Installed</span>
+        <span className="text-green-400">✓ EPO Circuit Bypassed</span>
       </div>
     );
   }
 
   return (
     <div className="border border-blue-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
-      <div className="text-blue-400 text-sm mb-2 font-mono">Install Tools:</div>
+      <div className="text-blue-400 text-sm mb-2 font-mono">Bypass EPO Circuit:</div>
       <div className="flex gap-2 mb-2">
         {!gear1Placed && (
           <div

--- a/client/src/components/puzzles/KeypadPuzzle.tsx
+++ b/client/src/components/puzzles/KeypadPuzzle.tsx
@@ -19,14 +19,14 @@ function KeypadPuzzle() {
   if (solved[0]) {
     return (
       <div className="border border-green-500 p-2 bg-green-900 bg-opacity-90 rounded">
-        <span className="text-green-400">✓ PDU Access Unlocked</span>
+        <span className="text-green-400">✓ Breaker Reset</span>
       </div>
     );
   }
 
   return (
     <div className="border border-red-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
-      <div className="text-red-400 text-sm mb-2 font-mono">PDU Access Code:</div>
+      <div className="text-red-400 text-sm mb-2 font-mono">Breaker Reset Code:</div>
       <div className="flex gap-1">
         <input
           type="text"

--- a/client/src/components/puzzles/ROT13Puzzle.tsx
+++ b/client/src/components/puzzles/ROT13Puzzle.tsx
@@ -18,14 +18,14 @@ function ROT13Puzzle() {
   if (solved[5]) {
     return (
       <div className="border border-green-500 p-2 bg-green-900 bg-opacity-90 rounded">
-        <span className="text-green-400">✓ Diagnostic Complete</span>
+        <span className="text-green-400">✓ Controller Rebooted</span>
       </div>
     );
   }
 
   return (
     <div className="border border-purple-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
-      <div className="text-purple-400 text-sm mb-1 font-mono">Error Code: RPDU</div>
+      <div className="text-purple-400 text-sm mb-1 font-mono">Reboot Code: RPDU</div>
       <input
         type="text"
         value={input}

--- a/client/src/components/puzzles/SliderPuzzle.tsx
+++ b/client/src/components/puzzles/SliderPuzzle.tsx
@@ -19,14 +19,14 @@ function SliderPuzzle() {
   if (solved[3]) {
     return (
       <div className="border border-green-500 p-2 bg-green-900 bg-opacity-90 rounded">
-        <span className="text-green-400">✓ Power Level Calibrated</span>
+        <span className="text-green-400">✓ Fuse Replaced</span>
       </div>
     );
   }
 
   return (
     <div className="border border-orange-500 p-2 bg-gray-800 bg-opacity-90 rounded hover:bg-opacity-100 transition-all duration-200 cursor-pointer">
-      <div className="text-orange-400 text-sm mb-1 font-mono">Power Level: {value}%</div>
+      <div className="text-orange-400 text-sm mb-1 font-mono">Fuse Rating: {value}%</div>
       <input
         type="range"
         min="0"

--- a/client/src/components/ui/EndScreen.tsx
+++ b/client/src/components/ui/EndScreen.tsx
@@ -28,7 +28,7 @@ export default function EndScreen() {
           <div className="mb-8">
             {isSuccess ? (
               <>
-                <p className="text-2xl text-white mb-4">Power restored. Access granted.</p>
+                <p className="text-2xl text-white mb-4">Controller online. Door unlocked.</p>
                 <p className="text-lg text-green-300">
                   Time remaining: {minutes}:{seconds.toString().padStart(2, '0')}
                 </p>

--- a/client/src/components/ui/GameOverlay.tsx
+++ b/client/src/components/ui/GameOverlay.tsx
@@ -42,25 +42,25 @@ function GameOverlay() {
         {/* PDU Status Display */}
         <div className="absolute top-4 left-4 pointer-events-auto">
           <div className="bg-gray-800 bg-opacity-90 border border-gray-500 p-3 rounded font-mono text-sm">
-            <div className="text-yellow-400 mb-2">PDU Status:</div>
+            <div className="text-yellow-400 mb-2">PDU Tasks:</div>
             <div className="space-y-1">
-              <div className={`${solved[0] ? 'text-green-400' : 'text-red-400'}`}>
-                ACCESS: {solved[0] ? 'UNLOCKED' : 'LOCKED'}
+              <div className={`${solved[0] ? 'text-green-400' : 'text-red-400'}`}> 
+                BREAKER: {solved[0] ? 'RESET' : 'TRIPPED'}
               </div>
-              <div className={`${solved[1] ? 'text-green-400' : 'text-red-400'}`}>
-                SEQUENCE: {solved[1] ? 'COMPLETE' : 'PENDING'}
+              <div className={`${solved[1] ? 'text-green-400' : 'text-red-400'}`}> 
+                WHIP: {solved[1] ? 'PATCHED' : 'FAULT'}
               </div>
-              <div className={`${solved[2] ? 'text-green-400' : 'text-red-400'}`}>
-                NETWORK: {solved[2] ? 'ONLINE' : 'OFFLINE'}
+              <div className={`${solved[2] ? 'text-green-400' : 'text-red-400'}`}> 
+                PHASES: {solved[2] ? 'BALANCED' : 'IMBALANCED'}
               </div>
-              <div className={`${solved[3] ? 'text-green-400' : 'text-red-400'}`}>
-                POWER: {solved[3] ? 'STABLE' : 'UNSTABLE'}
+              <div className={`${solved[3] ? 'text-green-400' : 'text-red-400'}`}> 
+                FUSE: {solved[3] ? 'REPLACED' : 'BLOWN'}
               </div>
-              <div className={`${solved[4] ? 'text-green-400' : 'text-red-400'}`}>
-                TOOLS: {solved[4] ? 'READY' : 'MISSING'}
+              <div className={`${solved[4] ? 'text-green-400' : 'text-red-400'}`}> 
+                EPO: {solved[4] ? 'BYPASSED' : 'ACTIVE'}
               </div>
-              <div className={`${solved[5] ? 'text-green-400' : 'text-red-400'}`}>
-                DIAG: {solved[5] ? 'CLEAR' : 'ERROR'}
+              <div className={`${solved[5] ? 'text-green-400' : 'text-red-400'}`}> 
+                CTRL: {solved[5] ? 'ONLINE' : 'OFFLINE'}
               </div>
             </div>
           </div>

--- a/client/src/components/ui/HintSystem.tsx
+++ b/client/src/components/ui/HintSystem.tsx
@@ -4,12 +4,12 @@ import { useGame } from "../../lib/stores/useGame";
 import { useEscapeRoom } from "../../lib/stores/useEscapeRoom";
 
 const HINTS = {
-  0: "Mathematics governs access. The circular constant, truncated to whole cents.",
-  1: "Primary colors in spectrum order, then the warm fusion of first two.",
-  2: "Sometimes the oldest solutions work best. Check what's monitoring the grid.",
-  3: "The answer to life, the universe, and everything... but as a percentage.",
-  4: "A mechanic needs their tools. Connect power where power belongs.",
-  5: "RPDU 📱"
+  0: "Mathematics controls the switch. Use the circular constant to reset.",
+  1: "Patch the whip by following the standard color order.",
+  2: "Tap the old phase meter to balance the load.",
+  3: "Set the replacement fuse to the meaning of life percent.",
+  4: "Jump the safety link with the correct connectors.",
+  5: "Decode the reboot string on the controller display."
 };
 
 export default function HintSystem() {
@@ -62,12 +62,12 @@ export default function HintSystem() {
                   : 'bg-yellow-700 hover:bg-yellow-600 text-yellow-100 cursor-pointer'
               }`}
             >
-              {puzzleIndex === 0 && "PDU Access"}
-              {puzzleIndex === 1 && "Sequence"}
-              {puzzleIndex === 2 && "Network"}
-              {puzzleIndex === 3 && "Power Level"}
-              {puzzleIndex === 4 && "Tools"}
-              {puzzleIndex === 5 && "Diagnostics"}
+              {puzzleIndex === 0 && "Reset Breaker"}
+              {puzzleIndex === 1 && "Repatch Whip"}
+              {puzzleIndex === 2 && "Balance Phases"}
+              {puzzleIndex === 3 && "Replace Fuse"}
+              {puzzleIndex === 4 && "Bypass EPO"}
+              {puzzleIndex === 5 && "Reboot Controller"}
             </button>
           ))}
         </div>

--- a/client/src/components/ui/SequenceIndicator.tsx
+++ b/client/src/components/ui/SequenceIndicator.tsx
@@ -19,7 +19,7 @@ function SequenceIndicator() {
   return (
     <div className="absolute top-4 left-1/2 transform -translate-x-1/2 pointer-events-auto">
       <div className="bg-gray-800 bg-opacity-90 border border-gray-500 p-2 rounded font-mono text-xs">
-        <div className="text-gray-400 mb-1 text-center">Activation Sequence</div>
+        <div className="text-gray-400 mb-1 text-center">Whip Patch Sequence</div>
         <div className="flex gap-1">
           {targetSequence.map((targetColor, index) => {
             const isActive = index < colorSequence.length;

--- a/client/src/components/ui/TitleScreen.tsx
+++ b/client/src/components/ui/TitleScreen.tsx
@@ -27,7 +27,13 @@ export default function TitleScreen() {
             </p>
             
             <div className="space-y-2">
-              <p>🛠 Drag and drop tools to fix five critical issues.</p>
+              <p>🛠 Resolve six power tasks to bring the rack online:</p>
+              <p className="text-sm pl-4">1. Reset the breaker</p>
+              <p className="text-sm pl-4">2. Repatch the whip</p>
+              <p className="text-sm pl-4">3. Balance the phases</p>
+              <p className="text-sm pl-4">4. Replace the blown fuse</p>
+              <p className="text-sm pl-4">5. Bypass the EPO circuit</p>
+              <p className="text-sm pl-4">6. Reboot the controller</p>
               <p>🔍 Hover over components to examine them.</p>
               <p>✅ Solve the issues in the correct order.</p>
               <p>⏱ You have 10 minutes before the backup power fails.</p>


### PR DESCRIPTION
## Summary
- theme puzzles around power maintenance tasks
- rename puzzle statuses and hints
- update instructions and end screen text

## Testing
- `npx tsx tests/addColorToSequence.test.ts` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_684c69dae040832b8d83666f0aa9eb6f